### PR TITLE
Initial docs for the project

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -24,7 +24,12 @@ Instead, the following API is what `CLI Testing Library` provides the following.
 - [`render` Result](#render-result)
   - [`...queries`](#queries)
     - [ByText](#bytext)
-  - [`fireEvent`](#fireevent)
+  - [`userEvent[eventName]`](#usereventeventname)
+  - [`debug`](#debug)
+  - [`hasExit`](#hasexit)
+  - [`process`](#process)
+  - [`stdoutArr`/`stderrArr`](#stdoutarrstderrarr)
+  - [`clear`](#clear)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -171,3 +176,43 @@ debug()
 
 This is a simple wrapper around `prettyCLI` which is also exposed and comes from
 [CLI Testing Library](./debug.md).
+
+## `hasExit`
+
+This method allows you to check if the spawned process has exit, and if so, what
+exit code it closed with.
+
+```javascript
+const instance = render('command')
+
+await waitFor(() => instance.hasExit()).toMatchObject({exitCode: 1})
+```
+
+This method returns `null` if still running, but `{exitCode: number}` if it has
+exit
+
+## `process`
+
+The spawned process created by your rendered `TestInstnace`. It's a
+`child_instance`. This is a
+[regularly spawned process](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options),
+so you can call `process.pid` etc. to inspect the process.
+
+## `stdoutArr`/`stderrArr`
+
+Each of these is an array of what's output by their respective `std`\* pipe.
+This is used internally to create the [`debug`methods](./debug.md) and more.
+They're defined as:
+
+```typescript
+interface TestInstance {
+  stdoutArr: Array<Buffer | string>
+  stderrArr: Array<Buffer | string>
+}
+```
+
+## `clear`
+
+This method acts as the terminal `clear` command might on most systems. It
+allows you to clear out the buffers for `stdoutArr` and `stderrArr` - even in
+the middle of processing - in order to do more narrowed queries.

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,6 +17,9 @@ Instead, the following API is what `CLI Testing Library` provides the following.
 - [`render` Options](#render-options)
   - [`cwd`](#cwd)
   - [`spawnOpts`](#spawnopts)
+- [`render` Result](#render-result)
+  - [`...queries`](#queries)
+    - [ByText](#bytext)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -87,3 +90,37 @@ const {getByText} = render('script.ps1', {
     }
 })
 ```
+
+# `render` Result
+
+The `render` method returns an object that has a few properties:
+
+## `...queries`
+
+The most important feature of render is that the queries from [CLI Testing Library](https://github.com/crutchcorn/cli-testing-library)
+are automatically returned with their first argument bound to the testInstance.
+
+See [Queries](./queries.md) to learn more about how to use these queries and the philosophy behind them.
+
+### ByText
+
+> getByText, queryByText, findByText
+
+```typescript
+getByText(
+        // If you're using `screen`, then skip the container argument:
+        instance: TestInstance,
+        text: TextMatch,
+        options?: {
+          exact?: boolean = true,
+          trim?: boolean = false,
+          stripAnsi?: boolean = false,
+          collapseWhitespace?: boolean = false,
+          normalizer?: NormalizerFn,
+          suggest?: boolean,
+        }): TestInstance
+```
+
+Queries for test instance `stdout` results with the given text (and it also accepts a TextMatch). 
+
+These options are all standard for text matching. To learn more, see our [Queries page](./queries.md).

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,89 @@
+# API
+
+`CLI Testing Library`, despite taking clear inspiration from, does not re-export anything
+from [`DOM Testing Library`](https://testing-library.com/docs/dom-testing-library/). Likewise,
+while we've done our best to match the API names of [Testing Library's Core API](https://testing-library.com/docs/),
+because of the inherent differences between CLI apps and web apps, we're unable to match all of them.
+
+> Know of a Testing Library Core API that you think would fit here that isn't present? [Let us know!](https://github.com/crutchcorn/cli-testing-library/issues)
+
+Instead, the following API is what `CLI Testing Library` provides the following.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [`render`](#render)
+- [`render` Options](#render-options)
+  - [`cwd`](#cwd)
+  - [`spawnOpts`](#spawnopts)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# `render`
+
+```typescript
+function render(
+    command: string,
+    args: string[],
+    options?: {
+        /* You won't often use this, expand below for docs on options */
+    },
+): RenderResult;
+```
+
+Run the CLI application in a newly spawned process.
+
+```javascript
+import {render} from 'cli-testing-library'
+
+render('node', ['./path/to/script.js'])
+```
+
+
+```javascript
+import {render} from 'cli-testing-library'
+
+test('renders a message', () => {
+    const {getByText} = render('node', ['./console-out.js']);
+    expect(getByText('Hello, world!')).toBeTruthy();
+});
+```
+
+# `render` Options
+
+You won't often need to specify options, but if you ever do,
+here are the available options which you could provide as a third argument to `render`.
+
+## `cwd`
+
+By default, `CLI Testing Library` will run the new process in the working directory
+of your project's root, as defined by your testing framework. If you provide your own
+working directory via this option, it will change the execution directory of your process.
+
+For example: If you are end-to-end testing a file moving script, you don't want to have
+to specify the absolute path every time. In this case, you can specify a directory as the render `cwd`.
+
+```javascript
+const containingPath = path.resolve(__dirname, './movables');
+
+const {getByText} = render('node', ['mover.js'], {
+    cwd: containingPath
+})
+```
+
+## `spawnOpts`
+
+Oftentimes, you want to modify the behavior of the spawn environment.
+This may include things like changing the shell that's used to run scripts or more.
+
+This argument allows you to configure the options that are passed to the underlying
+[`child_process.spawn` NodeJS API](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options).
+
+```javascript
+const {getByText} = render('script.ps1', {
+    spawnOpts: {
+        shell: 'powershell.exe'
+    }
+})
+```

--- a/docs/api.md
+++ b/docs/api.md
@@ -124,3 +124,12 @@ getByText(
 Queries for test instance `stdout` results with the given text (and it also accepts a TextMatch). 
 
 These options are all standard for text matching. To learn more, see our [Queries page](./queries.md).
+
+## `fireEvent`
+
+```javascript
+fireEvent(instance: TestInstace, event: Event)
+```
+
+> While `fireEvent` isn't usually returned on `render` in, say, `React Testing Library`, we're able to do
+> so because of our differences in implementation with upstream. See our [Differences](./differences.md) doc for more.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,17 +1,21 @@
 # API
 
-`CLI Testing Library`, despite taking clear inspiration from, does not re-export anything
-from [`DOM Testing Library`](https://testing-library.com/docs/dom-testing-library/). Likewise,
-while we've done our best to match the API names of [Testing Library's Core API](https://testing-library.com/docs/),
-because of the inherent differences between CLI apps and web apps, we're unable to match all of them.
+`CLI Testing Library`, despite taking clear inspiration from, does not re-export
+anything from
+[`DOM Testing Library`](https://testing-library.com/docs/dom-testing-library/).
+Likewise, while we've done our best to match the API names of
+[Testing Library's Core API](https://testing-library.com/docs/), because of the
+inherent differences between CLI apps and web apps, we're unable to match all of
+them.
 
-> Know of a Testing Library Core API that you think would fit here that isn't present? [Let us know!](https://github.com/crutchcorn/cli-testing-library/issues)
+> Know of a Testing Library Core API that you think would fit here that isn't
+> present?
+> [Let us know!](https://github.com/crutchcorn/cli-testing-library/issues)
 
 Instead, the following API is what `CLI Testing Library` provides the following.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 
 - [`render`](#render)
 - [`render` Options](#render-options)
@@ -20,6 +24,7 @@ Instead, the following API is what `CLI Testing Library` provides the following.
 - [`render` Result](#render-result)
   - [`...queries`](#queries)
     - [ByText](#bytext)
+  - [`fireEvent`](#fireevent)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -27,12 +32,12 @@ Instead, the following API is what `CLI Testing Library` provides the following.
 
 ```typescript
 function render(
-    command: string,
-    args: string[],
-    options?: {
-        /* You won't often use this, expand below for docs on options */
-    },
-): RenderResult;
+  command: string,
+  args: string[],
+  options?: {
+    /* You won't often use this, expand below for docs on options */
+  },
+): RenderResult
 ```
 
 Run the CLI application in a newly spawned process.
@@ -43,51 +48,53 @@ import {render} from 'cli-testing-library'
 render('node', ['./path/to/script.js'])
 ```
 
-
 ```javascript
 import {render} from 'cli-testing-library'
 
 test('renders a message', () => {
-    const {getByText} = render('node', ['./console-out.js']);
-    expect(getByText('Hello, world!')).toBeTruthy();
-});
+  const {getByText} = render('node', ['./console-out.js'])
+  expect(getByText('Hello, world!')).toBeTruthy()
+})
 ```
 
 # `render` Options
 
-You won't often need to specify options, but if you ever do,
-here are the available options which you could provide as a third argument to `render`.
+You won't often need to specify options, but if you ever do, here are the
+available options which you could provide as a third argument to `render`.
 
 ## `cwd`
 
-By default, `CLI Testing Library` will run the new process in the working directory
-of your project's root, as defined by your testing framework. If you provide your own
-working directory via this option, it will change the execution directory of your process.
+By default, `CLI Testing Library` will run the new process in the working
+directory of your project's root, as defined by your testing framework. If you
+provide your own working directory via this option, it will change the execution
+directory of your process.
 
-For example: If you are end-to-end testing a file moving script, you don't want to have
-to specify the absolute path every time. In this case, you can specify a directory as the render `cwd`.
+For example: If you are end-to-end testing a file moving script, you don't want
+to have to specify the absolute path every time. In this case, you can specify a
+directory as the render `cwd`.
 
 ```javascript
-const containingPath = path.resolve(__dirname, './movables');
+const containingPath = path.resolve(__dirname, './movables')
 
 const {getByText} = render('node', ['mover.js'], {
-    cwd: containingPath
+  cwd: containingPath,
 })
 ```
 
 ## `spawnOpts`
 
-Oftentimes, you want to modify the behavior of the spawn environment.
-This may include things like changing the shell that's used to run scripts or more.
+Oftentimes, you want to modify the behavior of the spawn environment. This may
+include things like changing the shell that's used to run scripts or more.
 
-This argument allows you to configure the options that are passed to the underlying
+This argument allows you to configure the options that are passed to the
+underlying
 [`child_process.spawn` NodeJS API](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options).
 
 ```javascript
 const {getByText} = render('script.ps1', {
-    spawnOpts: {
-        shell: 'powershell.exe'
-    }
+  spawnOpts: {
+    shell: 'powershell.exe',
+  },
 })
 ```
 
@@ -97,10 +104,12 @@ The `render` method returns an object that has a few properties:
 
 ## `...queries`
 
-The most important feature of render is that the queries from [CLI Testing Library](https://github.com/crutchcorn/cli-testing-library)
-are automatically returned with their first argument bound to the testInstance.
+The most important feature of render is that the queries from
+[CLI Testing Library](https://github.com/crutchcorn/cli-testing-library) are
+automatically returned with their first argument bound to the testInstance.
 
-See [Queries](./queries.md) to learn more about how to use these queries and the philosophy behind them.
+See [Queries](./queries.md) to learn more about how to use these queries and the
+philosophy behind them.
 
 ### ByText
 
@@ -121,9 +130,11 @@ getByText(
         }): TestInstance
 ```
 
-Queries for test instance `stdout` results with the given text (and it also accepts a TextMatch). 
+Queries for test instance `stdout` results with the given text (and it also
+accepts a TextMatch).
 
-These options are all standard for text matching. To learn more, see our [Queries page](./queries.md).
+These options are all standard for text matching. To learn more, see our
+[Queries page](./queries.md).
 
 ## `fireEvent`
 
@@ -131,5 +142,7 @@ These options are all standard for text matching. To learn more, see our [Querie
 fireEvent(instance: TestInstace, event: Event)
 ```
 
-> While `fireEvent` isn't usually returned on `render` in, say, `React Testing Library`, we're able to do
-> so because of our differences in implementation with upstream. See our [Differences](./differences.md) doc for more.
+> While `fireEvent` isn't usually returned on `render` in, say,
+> `React Testing Library`, we're able to do so because of our differences in
+> implementation with upstream. See our [Differences](./differences.md) doc for
+> more.

--- a/docs/api.md
+++ b/docs/api.md
@@ -136,13 +136,38 @@ accepts a TextMatch).
 These options are all standard for text matching. To learn more, see our
 [Queries page](./queries.md).
 
-## `fireEvent`
+## `userEvent[eventName]`
 
 ```javascript
-fireEvent(instance: TestInstace, event: Event)
+userEvent[eventName](...eventProps)
 ```
 
-> While `fireEvent` isn't usually returned on `render` in, say,
+> While `userEvent` isn't usually returned on `render` in, say,
 > `React Testing Library`, we're able to do so because of our differences in
 > implementation with upstream. See our [Differences](./differences.md) doc for
 > more.
+
+This object is the same as described with
+[`userEvent` documentation](./user-event.md) with the key difference that
+`instance` is not expected to be passed when bound to `render`.
+
+## `debug`
+
+This method is a shortcut for `console.log(prettyCLI(instance)).`
+
+```javascript
+import {render} from 'cli-testing-library'
+
+const {debug} = render('command')
+debug()
+// Hello, world! How are you?
+//
+// you can also pass an instance: debug(getByText('message'))
+// and you can pass all the same arguments to debug as you can
+// to prettyCLI:
+// const maxLengthToPrint = 10000
+// debug(getByText('message'), maxLengthToPrint)
+```
+
+This is a simple wrapper around `prettyCLI` which is also exposed and comes from
+[CLI Testing Library](./debug.md).

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -1,0 +1,78 @@
+# Configuration Options
+
+## Introduction
+
+The library can be configured via the `configure` function, which accepts:
+
+- a plain JS object; this will be merged into the existing configuration. e.g.
+  `configure({testIdAttribute: 'not-data-testid'})`
+- a function; the function will be given the existing configuration, and should
+  return a plain JS object which will be merged as above, e.g.
+  `configure(existingConfig => ({something: [...existingConfig.something, 'extra value for the something array']}))`
+
+> **Note**
+>
+> Framework-specific wrappers like React Testing Library may add more options to
+> the ones shown below.
+
+```js title="setup-tests.js"
+import {configure} from '@testing-library/react'
+
+configure({testIdAttribute: 'data-my-test-id'})
+```
+
+## Options
+
+### `computedStyleSupportsPseudoElements`
+
+Set to `true` if `window.getComputedStyle` supports pseudo-elements i.e. a
+second argument. If you're using testing-library in a browser you almost always
+want to set this to `true`. Only very old browser don't support this property
+(such as IE 8 and earlier). However, `jsdom` does not support the second
+argument currently. This includes versions of `jsdom` prior to `16.4.0` and any
+version that logs a `not implemented` warning when calling `getComputedStyle`
+with a second argument e.g.
+`window.getComputedStyle(document.createElement('div'), '::after')`. Defaults to
+`false`
+
+### `defaultHidden`
+
+The default value for the `hidden` option used by
+[`getByRole`](queries/byrole.mdx). Defaults to `false`.
+
+### `showOriginalStackTrace`
+
+By default, `waitFor` will ensure that the stack trace for errors thrown by
+Testing Library is cleaned up and shortened so it's easier for you to identify
+the part of your code that resulted in the error (async stack traces are hard to
+debug). If you want to disable this, then set`showOriginalStackTrace` to
+`false`. You can also disable this for a specific call in the options you pass
+to `waitFor`.
+
+### `throwSuggestions` (experimental)
+
+When enabled, if [better queries](queries/about.mdx#priority) are available the
+test will fail and provide a suggested query to use instead. Default to `false`.
+
+To disable a suggestion for a single query just add `{suggest:false}` as an
+option.
+
+```js
+screen.getByTestId('foo', {suggest: false}) // will not throw a suggestion
+```
+
+### `testIdAttribute`
+
+The attribute used by [`getByTestId`](queries/bytestid.mdx) and related queries.
+Defaults to `data-testid`.
+
+### `getElementError`
+
+A function that returns the error used when
+[get or find queries](queries/about.mdx#types-of-queries) fail. Takes the error
+message and container object as arguments.
+
+### `asyncUtilTimeout`
+
+The global timeout value in milliseconds used by `waitFor` utilities. Defaults
+to 1000ms.

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -5,40 +5,12 @@
 The library can be configured via the `configure` function, which accepts:
 
 - a plain JS object; this will be merged into the existing configuration. e.g.
-  `configure({testIdAttribute: 'not-data-testid'})`
+  `configure({asyncUtilTimeout: 800})`
 - a function; the function will be given the existing configuration, and should
   return a plain JS object which will be merged as above, e.g.
   `configure(existingConfig => ({something: [...existingConfig.something, 'extra value for the something array']}))`
 
-> **Note**
->
-> Framework-specific wrappers like React Testing Library may add more options to
-> the ones shown below.
-
-```js title="setup-tests.js"
-import {configure} from '@testing-library/react'
-
-configure({testIdAttribute: 'data-my-test-id'})
-```
-
 ## Options
-
-### `computedStyleSupportsPseudoElements`
-
-Set to `true` if `window.getComputedStyle` supports pseudo-elements i.e. a
-second argument. If you're using testing-library in a browser you almost always
-want to set this to `true`. Only very old browser don't support this property
-(such as IE 8 and earlier). However, `jsdom` does not support the second
-argument currently. This includes versions of `jsdom` prior to `16.4.0` and any
-version that logs a `not implemented` warning when calling `getComputedStyle`
-with a second argument e.g.
-`window.getComputedStyle(document.createElement('div'), '::after')`. Defaults to
-`false`
-
-### `defaultHidden`
-
-The default value for the `hidden` option used by
-[`getByRole`](queries/byrole.mdx). Defaults to `false`.
 
 ### `showOriginalStackTrace`
 
@@ -51,28 +23,34 @@ to `waitFor`.
 
 ### `throwSuggestions` (experimental)
 
-When enabled, if [better queries](queries/about.mdx#priority) are available the
+When enabled, if [better queries](./queries.md) are available the
 test will fail and provide a suggested query to use instead. Default to `false`.
 
 To disable a suggestion for a single query just add `{suggest:false}` as an
 option.
 
 ```js
-screen.getByTestId('foo', {suggest: false}) // will not throw a suggestion
+getByText('foo', {suggest: false}) // will not throw a suggestion
 ```
 
-### `testIdAttribute`
-
-The attribute used by [`getByTestId`](queries/bytestid.mdx) and related queries.
-Defaults to `data-testid`.
-
-### `getElementError`
+### `getInstanceError`
 
 A function that returns the error used when
-[get or find queries](queries/about.mdx#types-of-queries) fail. Takes the error
-message and container object as arguments.
+[get or find queries](./queries.md#types-of-queries) fail. Takes the error
+message and `TestInstance` object as arguments.
 
 ### `asyncUtilTimeout`
 
 The global timeout value in milliseconds used by `waitFor` utilities. Defaults
 to 1000ms.
+
+### `renderAwaitTime`
+
+By default, we wait for the CLI to `spawn` the command from `render`. If we immediately resolve 
+the promise to allow users to query, however, we lose the ability to `getByText` immediately after rendering.
+This [differs greatly from upstream Testing Library](./differences.md) and makes for a poor testing experience.
+
+As a result, we wait this duration before resolving the promise after the process is spawned. This gives runtimes like
+NodeJS time to spin up and execute commands.
+
+Defaults to 100ms.

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -1,0 +1,56 @@
+# Debug
+
+## Automatic Logging
+
+When you use any `get` calls in your test cases, the current state of the
+`testInstance` (CLI) gets printed on the console. For example:
+
+```javascript
+// Hello world
+getByText(container, 'Goodbye world') // will fail by throwing error
+```
+
+The above test case will fail, however it prints the state of your DOM under
+test, so you will get to see:
+
+```
+Unable to find an element with the text: Goodbye world. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.
+Here is the state of your container:
+
+Hello world
+```
+
+Note: Since the CLI size can get really large, you can set the limit of CLI
+content to be printed via environment variable `DEBUG_PRINT_LIMIT`. The default
+value is `7000`. You will see `...` in the console, when the CLI content is
+stripped off, because of the length you have set or due to default size limit.
+Here's how you might increase this limit when running tests:
+
+```
+DEBUG_PRINT_LIMIT=10000 npm test
+```
+
+This works on macOS/Linux, you'll need to do something else for Windows. If
+you'd like a solution that works for both, see
+[`cross-env`](https://www.npmjs.com/package/cross-env).
+
+## `prettyCLI`
+
+Built on top of [`strip-ansi`](https://github.com/chalk/strip-ansi) this helper
+function can be used to print out readable representation of the CLI `stdout` of
+a process. This can be helpful for instance when debugging tests.
+
+It is defined as:
+
+```typescript
+function prettyDOM(instance: TestInstance, maxLength?: number): string
+```
+
+It receives the `TestInstance` to print out, an optional extra parameter to
+limit the size of the resulting string, for cases when it becomes too large.
+
+This function is usually used alongside `console.log` to temporarily print out
+CLI outputs during tests for debugging purposes:
+
+This function is what also powers
+[the automatic debugging output described above](#debugging).

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -1,17 +1,20 @@
 # Differences Between `cli-testing-library` & Testing Library
 
-While we clearly take inspiration from [`DOM Testing Library`](https://github.com/testing-library/dom-testing-library)
-and [`React Testing Library`](https://github.com/testing-library/react-testing-library),
-and try to do our best to align as much as possible, there are some major distinctions between
-the project's APIs.
+While we clearly take inspiration from
+[`DOM Testing Library`](https://github.com/testing-library/dom-testing-library)
+and
+[`React Testing Library`](https://github.com/testing-library/react-testing-library),
+and try to do our best to align as much as possible, there are some major
+distinctions between the project's APIs.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Instances](#instances)
 - [Queries](#queries)
 - [Events](#events)
+  - [FireEvent](#fireevent)
+  - [UserEvent](#userevent)
 - [Matchers](#matchers)
 - [Similarities](#similarities)
 
@@ -19,100 +22,127 @@ the project's APIs.
 
 # Instances
 
-While the `DOM Testing Library` and it's descendants have a concept of both a `container` and `element`, `CLI Testing Library`
-only has a single concept to replace them both: a `TestInstance`.
+While the `DOM Testing Library` and it's descendants have a concept of both a
+`container` and `element`, `CLI Testing Library` only has a single concept to
+replace them both: a `TestInstance`.
 
-This is because, while the DOM makes a clear distinction between different elements (say, [`HTMLBodyElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLBodyElement)
-and [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement)), there is no such distinction between
-processes in the CLI as far as I'm aware.
+This is because, while the DOM makes a clear distinction between different
+elements (say,
+[`HTMLBodyElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLBodyElement)
+and
+[`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement)),
+there is no such distinction between processes in the CLI as far as I'm aware.
 
-While this may change in the future (maybe `container` can be a sort of `TestProcess` of some kind), there are
+While this may change in the future (maybe `container` can be a sort of
+`TestProcess` of some kind), there are
 [unanswered questions around what that API looks like and whether we can meaningfully handle the distinction](https://github.com/crutchcorn/cli-testing-library/issues/2).
 
 # Queries
 
-Similarly, `HTMLElement`s provide clean lines between user input items. Meanwhile, the CLI only has the concepts of `stdin`, `stdout`, and `stderr`.
-It's unclear how matching a single line of `stdout` would help in a beneficial matter, much less how APIs like `fireEvent`
-would utilize this seemingly extraneous metadata.
+Similarly, `HTMLElement`s provide clean lines between user input items.
+Meanwhile, the CLI only has the concepts of `stdin`, `stdout`, and `stderr`.
+It's unclear how matching a single line of `stdout` would help in a beneficial
+matter, much less how APIs like `fireEvent` would utilize this seemingly
+extraneous metadata.
 
-As a result, we don't have any `*AllBy` queries that `DOM Testing Library` does. All of our queries are non-plural (`*By`)
-and will simply return either the test instance the query was called on, or `null` depending on the query.
+As a result, we don't have any `*AllBy` queries that `DOM Testing Library` does.
+All of our queries are non-plural (`*By`) and will simply return either the test
+instance the query was called on, or `null` depending on the query.
 
 While we would be happy to reconsider, there are once again
 [lots of questions around what `*AllBy` queries would like and whether we can meaningfully use that concept](https://github.com/crutchcorn/cli-testing-library/issues/2).
 
 # Events
 
-Another area where we diverge from the DOM is in our event system (as implemented via `fireEvent` and `userEvent`).
+Another area where we diverge from the DOM is in our event system (as
+implemented via `fireEvent` and `userEvent`).
 
-Despite our APIs' naming indicating an actual event system (complete with bubbling and more, like the DOM),
-the CLI has no such concept.
+Despite our APIs' naming indicating an actual event system (complete with
+bubbling and more, like the DOM), the CLI has no such concept.
 
 ### FireEvent
 
-This means that, while `fireEvent` in the `DOM Testing Library` has the ability to inherent from all
-baked-into-browser events, we must hard-code a list of "events" and actions a user may take.
+This means that, while `fireEvent` in the `DOM Testing Library` has the ability
+to inherent from all baked-into-browser events, we must hard-code a list of
+"events" and actions a user may take.
 
 We try our best to implement ones that make sense:
 
 - `fireEvent.write({value: str})` to write `str` into stdin
-- `fireEvent.sigkill()` to send a [sigkill](https://en.wikipedia.org/wiki/Signal_(IPC)#SIGKILL) to the process
-- `fireEvent.sigint()` to send a [sigint](https://en.wikipedia.org/wiki/Signal_(IPC)#SIGINT) to the process
+- `fireEvent.sigkill()` to send a
+  [sigkill](<https://en.wikipedia.org/wiki/Signal_(IPC)#SIGKILL>) to the process
+- `fireEvent.sigint()` to send a
+  [sigint](<https://en.wikipedia.org/wiki/Signal_(IPC)#SIGINT>) to the process
 
-There is a missing API for that might make sense in `keypress`. It's unclear what this behavior would do that `write` wouldn't
-be able to.
+There is a missing API for that might make sense in `keypress`. It's unclear
+what this behavior would do that `write` wouldn't be able to.
 
 ### UserEvent
 
-There's also the API of `userEvent` that allows us to implement a fairly similar `keyboard` event
-[to upstream](https://testing-library.com/docs/ecosystem-user-event/#keyboardtext-options). However, there are a few differences
-here as well:
+There's also the API of `userEvent` that allows us to implement a fairly similar
+`keyboard` event
+[to upstream](https://testing-library.com/docs/ecosystem-user-event/#keyboardtext-options).
+However, there are a few differences here as well:
 
-1) `userEvent` can be bound to the `render` output. This is due to limitations of not having a `screen` API. It's unclear how
-    this would work in practice, due to a lack of the `window` API.
-2) `userEvent.keyboard` does not support modifier keys. It's only key-presses, no holding. This is because of API 
-    differences that would require us to figure out a manual binding system for every single key using ANSI AFAIK.
-3) Relatedly, we've remove the `{` syntax support, since there is no standard keybinding for the CLI, [like there is for the DOM](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code). Instead, we only support `[` and `]` syntax.
+1. `userEvent` can be bound to the `render` output. This is due to limitations
+   of not having a `screen` API. It's unclear how this would work in practice,
+   due to a lack of the `window` API.
+2. `userEvent.keyboard` does not support modifier keys. It's only key-presses,
+   no holding. This is because of API differences that would require us to
+   figure out a manual binding system for every single key using ANSI AFAIK.
+3. Relatedly, we've remove the `{` syntax support, since there is no standard
+   keybinding for the CLI,
+   [like there is for the DOM](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code).
+   Instead, we only support `[` and `]` syntax.
 
 # Matchers
 
-While most of this document has been talking about `DOM Testing Library` and `React Testing Library`,
-let's take a moment to talk about [`jest-dom`](https://github.com/testing-library/jest-dom) matchers.
+While most of this document has been talking about `DOM Testing Library` and
+`React Testing Library`, let's take a moment to talk about
+[`jest-dom`](https://github.com/testing-library/jest-dom) matchers.
 
-Usually, in a Testing Library testbed, you'd expect a `getByText` to look something like this:
-
-```javascript
-const {getByText} = render(/* Something */)
-
-expect(getByText('Hello World')).toBeInTheDocument();
-```
-
-However, in today's version of `CLI Testing Library`, the same would look something like this:
+Usually, in a Testing Library testbed, you'd expect a `getByText` to look
+something like this:
 
 ```javascript
 const {getByText} = render(/* Something */)
 
-expect(getByText('Hello World')).toBeTruthy();
+expect(getByText('Hello World')).toBeInTheDocument()
 ```
 
-This is because, unlike `DOM Testing Library`, our TestInstances do not have parental relationships. As
-a result, what would be a fitting replacement for `document`?
+However, in today's version of `CLI Testing Library`, the same would look
+something like this:
 
-That said, because `toBeInTheDocument` is implemented by `jest-dom`, we can absolutely implement something
-similar in our codebase if requested. We have some thoughts around the technical aspects, but [we'd love to jump
-deeper into that discussion with others](https://github.com/crutchcorn/cli-testing-library/issues/2)
+```javascript
+const {getByText} = render(/* Something */)
+
+expect(getByText('Hello World')).toBeTruthy()
+```
+
+This is because, unlike `DOM Testing Library`, our TestInstances do not have
+parental relationships. As a result, what would be a fitting replacement for
+`document`?
+
+That said, because `toBeInTheDocument` is implemented by `jest-dom`, we can
+absolutely implement something similar in our codebase if requested. We have
+some thoughts around the technical aspects, but
+[we'd love to jump deeper into that discussion with others](https://github.com/crutchcorn/cli-testing-library/issues/2)
 
 # Similarities
 
-None of this is to say that we're not dedicated to being aligned with upstream. We would love to work with the broader Testing Library
-community to figure out these problems and adjust our usage.
+None of this is to say that we're not dedicated to being aligned with upstream.
+We would love to work with the broader Testing Library community to figure out
+these problems and adjust our usage.
 
-This is the primary reason the library is still published as an `@alpha`, despite being stable enough to successfully
-power [a popular CLI application](https://github.com/plopjs/plop/)'s testbed.
+This is the primary reason the library is still published as an `@alpha`,
+despite being stable enough to successfully power
+[a popular CLI application](https://github.com/plopjs/plop/)'s testbed.
 
-What's more, we're dedicated enough to making this happen that we've made sure to:
+What's more, we're dedicated enough to making this happen that we've made sure
+to:
 
-- Use the same source code organization (as much as possible) as `DOM Testing Library` and `React Testing Library`
+- Use the same source code organization (as much as possible) as
+  `DOM Testing Library` and `React Testing Library`
 - Use the same deployment process as `DOM Testing Library`
 - Use similar documentation styles
 

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -110,23 +110,14 @@ const {getByText} = render(/* Something */)
 expect(getByText('Hello World')).toBeInTheDocument()
 ```
 
-However, in today's version of `CLI Testing Library`, the same would look
-something like this:
+In today's version of `CLI Testing Library`, the same would look something like
+this:
 
 ```javascript
 const {getByText} = render(/* Something */)
 
-expect(getByText('Hello World')).toBeTruthy()
+expect(getByText('Hello World')).toBeInTheConsole()
 ```
-
-This is because, unlike `DOM Testing Library`, our TestInstances do not have
-parental relationships. As a result, what would be a fitting replacement for
-`document`?
-
-That said, because `toBeInTheDocument` is implemented by `jest-dom`, we can
-absolutely implement something similar in our codebase if requested. We have
-some thoughts around the technical aspects, but
-[we'd love to jump deeper into that discussion with others](https://github.com/crutchcorn/cli-testing-library/issues/2)
 
 # Similarities
 

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -1,0 +1,56 @@
+# Differences Between `@testing-library/dom` and `cli-testing-library`
+
+While we clearly take inspiration from [`DOM Testing Library`](https://github.com/testing-library/dom-testing-library)
+and [`React Testing Library`](https://github.com/testing-library/react-testing-library),
+and try to do our best to align as much as possible, there are some major distinctions between
+the project's APIs.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Instances](#instances)
+- [Queries](#queries)
+- [Similarities](#similarities)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Instances
+
+While the `DOM Testing Library` and it's descendants have a concept of both a `container` and `element`, `CLI Testing Library`
+only has a single concept to replace them both: a `TestInstance`.
+
+This is because, while the DOM makes a clear distinction between different elements (say, [`HTMLBodyElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLBodyElement)
+and [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement)), there is no such distinction between
+processes in the CLI as far as I'm aware.
+
+While this may change in the future (maybe `container` can be a sort of `TestProcess` of some kind), there are
+[unanswered questions around what that API looks like and whether we can meaningfully handle the distinction](https://github.com/crutchcorn/cli-testing-library/issues/2).
+
+# Queries
+
+Similarly, `HTMLElement`s provide clean lines between user input items. Meanwhile, the CLI only has the concepts of `stdin`, `stdout`, and `stderr`.
+It's unclear how matching a single line of `stdout` would help in a beneficial matter, much less how APIs like `fireEvent`
+would utilize this seemingly extraneous metadata.
+
+As a result, we don't have any `*AllBy` queries that `DOM Testing Library` does. All of our queries are non-plural (`*By`)
+and will simply return either the test instance the query was called on, or `null` depending on the query.
+
+While we would be happy to reconsider, there are once again
+[lots of questions around what `*AllBy` queries would like and whether we can meaningfully use that concept](https://github.com/crutchcorn/cli-testing-library/issues/2).
+
+# Similarities
+
+This isn't to say that we're not dedicated to being aligned with upstream. We would love to work with the broader Testing Library
+community to figure out these problems and adjust our usage.
+
+This is the primary reason the library is still published as an `@alpha`, despite being stable enough to successfully
+power [a popular CLI application](https://github.com/plopjs/plop/)'s testbed.
+
+What's more, we're dedicated enough to making this happen that we've made sure to:
+
+- Use the same source code organization (as much as possible) as `DOM Testing Library` and `React Testing Library`
+- Use the same deployment process as `DOM Testing Library`
+- Use similar documentation styles
+
+And more!

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -11,6 +11,8 @@ the project's APIs.
 
 - [Instances](#instances)
 - [Queries](#queries)
+- [Events](#events)
+- [Matchers](#matchers)
 - [Similarities](#similarities)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -39,9 +41,56 @@ and will simply return either the test instance the query was called on, or `nul
 While we would be happy to reconsider, there are once again
 [lots of questions around what `*AllBy` queries would like and whether we can meaningfully use that concept](https://github.com/crutchcorn/cli-testing-library/issues/2).
 
+# Events
+
+Another area where we diverge from the DOM is in our event system (as implemented via `fireEvent`).
+
+Despite our APIs naming indicating an actual event system (complete with bubbling and more, like the DOM),
+the CLI has no such concept.
+
+This means that, while `fireEvent` in the `DOM Testing Library` has the ability to inherent from all
+baked-into-browser events, we must hard-code a list of "events" and actions a user may take.
+
+We try our best to implement ones that make sense:
+
+- `fireEvent.up()` for keyboard up
+- `fireEvent.type(str)` to write code into stdin
+- `fireEvent.sigkill()` to send a [sigkill](https://en.wikipedia.org/wiki/Signal_(IPC)#SIGKILL) to the process
+
+But there are avenues where this diverges from upstream. [We have an open list of questions about how we can
+make our events align more with upstream](https://github.com/crutchcorn/cli-testing-library/issues/2)
+
+# Matchers
+
+While most of this document has been talking about `DOM Testing Library` and `React Testing Library`,
+let's take a moment to talk about [`jest-dom`](https://github.com/testing-library/jest-dom) matchers.
+
+Usually, in a Testing Library testbed, you'd expect a `getByText` to look something like this:
+
+```javascript
+const {getByText} = render(/* Something */)
+
+expect(getByText('Hello World')).toBeInTheDocument();
+```
+
+However, in today's version of `CLI Testing Library`, the same would look something like this:
+
+```javascript
+const {getByText} = render(/* Something */)
+
+expect(getByText('Hello World')).toBeTruthy();
+```
+
+This is because, unlike `DOM Testing Library`, our TestInstances do not have parental relationships. As
+a result, what would be a fitting replacement for `document`?
+
+That said, because `toBeInTheDocument` is implemented by `jest-dom`, we can absolutely implement something
+similar in our codebase if requested. We have some thoughts around the technical aspects, but [we'd love to jump
+deeper into that discussion with others](https://github.com/crutchcorn/cli-testing-library/issues/2)
+
 # Similarities
 
-This isn't to say that we're not dedicated to being aligned with upstream. We would love to work with the broader Testing Library
+None of this is to say that we're not dedicated to being aligned with upstream. We would love to work with the broader Testing Library
 community to figure out these problems and adjust our usage.
 
 This is the primary reason the library is still published as an `@alpha`, despite being stable enough to successfully

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -48,6 +48,8 @@ Another area where we diverge from the DOM is in our event system (as implemente
 Despite our APIs' naming indicating an actual event system (complete with bubbling and more, like the DOM),
 the CLI has no such concept.
 
+### FireEvent
+
 This means that, while `fireEvent` in the `DOM Testing Library` has the ability to inherent from all
 baked-into-browser events, we must hard-code a list of "events" and actions a user may take.
 
@@ -60,6 +62,8 @@ We try our best to implement ones that make sense:
 There is a missing API for that might make sense in `keypress`. It's unclear what this behavior would do that `write` wouldn't
 be able to.
 
+### UserEvent
+
 There's also the API of `userEvent` that allows us to implement a fairly similar `keyboard` event
 [to upstream](https://testing-library.com/docs/ecosystem-user-event/#keyboardtext-options). However, there are a few differences
 here as well:
@@ -68,6 +72,7 @@ here as well:
     this would work in practice, due to a lack of the `window` API.
 2) `userEvent.keyboard` does not support modifier keys. It's only key-presses, no holding. This is because of API 
     differences that would require us to figure out a manual binding system for every single key using ANSI AFAIK.
+3) Relatedly, we've remove the `{` syntax support, since there is no standard keybinding for the CLI, [like there is for the DOM](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code). Instead, we only support `[` and `]` syntax.
 
 # Matchers
 

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -1,4 +1,4 @@
-# Differences Between `@testing-library/dom` and `cli-testing-library`
+# Differences Between `cli-testing-library` & Testing Library
 
 While we clearly take inspiration from [`DOM Testing Library`](https://github.com/testing-library/dom-testing-library)
 and [`React Testing Library`](https://github.com/testing-library/react-testing-library),
@@ -43,9 +43,9 @@ While we would be happy to reconsider, there are once again
 
 # Events
 
-Another area where we diverge from the DOM is in our event system (as implemented via `fireEvent`).
+Another area where we diverge from the DOM is in our event system (as implemented via `fireEvent` and `userEvent`).
 
-Despite our APIs naming indicating an actual event system (complete with bubbling and more, like the DOM),
+Despite our APIs' naming indicating an actual event system (complete with bubbling and more, like the DOM),
 the CLI has no such concept.
 
 This means that, while `fireEvent` in the `DOM Testing Library` has the ability to inherent from all
@@ -53,12 +53,21 @@ baked-into-browser events, we must hard-code a list of "events" and actions a us
 
 We try our best to implement ones that make sense:
 
-- `fireEvent.up()` for keyboard up
-- `fireEvent.type(str)` to write code into stdin
+- `fireEvent.write({value: str})` to write `str` into stdin
 - `fireEvent.sigkill()` to send a [sigkill](https://en.wikipedia.org/wiki/Signal_(IPC)#SIGKILL) to the process
+- `fireEvent.sigint()` to send a [sigint](https://en.wikipedia.org/wiki/Signal_(IPC)#SIGINT) to the process
 
-But there are avenues where this diverges from upstream. [We have an open list of questions about how we can
-make our events align more with upstream](https://github.com/crutchcorn/cli-testing-library/issues/2)
+There is a missing API for that might make sense in `keypress`. It's unclear what this behavior would do that `write` wouldn't
+be able to.
+
+There's also the API of `userEvent` that allows us to implement a fairly similar `keyboard` event
+[to upstream](https://testing-library.com/docs/ecosystem-user-event/#keyboardtext-options). However, there are a few differences
+here as well:
+
+1) `userEvent` can be bound to the `render` output. This is due to limitations of not having a `screen` API. It's unclear how
+    this would work in practice, due to a lack of the `window` API.
+2) `userEvent.keyboard` does not support modifier keys. It's only key-presses, no holding. This is because of API 
+    differences that would require us to figure out a manual binding system for every single key using ANSI AFAIK.
 
 # Matchers
 

--- a/docs/fire-event.md
+++ b/docs/fire-event.md
@@ -27,5 +27,5 @@ fireEvent[eventName](instance: TestInstance, eventProperties?: Object)
 ```
 
 Convenience methods for firing CLI events. Check out
-[src/event-map.js](https://github.com/crutchcorn/cli-testing-library/blob/main/src/event-map.js)
+[src/event-map.js](../src/event-map.ts)
 for a full list as well as default `eventProperties`.

--- a/docs/fire-event.md
+++ b/docs/fire-event.md
@@ -1,0 +1,31 @@
+# Firing Events
+
+> **Note**
+>
+> Most projects have a few use cases for `fireEvent`, but the majority of the time you should probably use [`userEvent`](./user-event).
+
+## `fireEvent`
+
+```typescript
+fireEvent(instance: TestInstance, event: EventString, eventProperties?: Object)
+```
+
+Fire CLI events.
+
+```javascript
+fireEvent(
+  getByText(instance, 'Username:'),
+  'write',
+  {value: 'crutchcorn'}
+)
+```
+
+## `fireEvent[eventName]`
+
+```typescript
+fireEvent[eventName](instance: TestInstance, eventProperties?: Object)
+```
+
+Convenience methods for firing CLI events. Check out
+[src/event-map.js](https://github.com/crutchcorn/cli-testing-library/blob/main/src/event-map.js)
+for a full list as well as default `eventProperties`.

--- a/docs/fire-event.md
+++ b/docs/fire-event.md
@@ -1,8 +1,21 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+**Table of Contents** _generated with
+[DocToc](https://github.com/thlorenz/doctoc)_
+
+- [Firing Events](#firing-events)
+  - [`fireEvent`](#fireevent)
+  - [`fireEvent[eventName]`](#fireeventeventname)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Firing Events
 
 > **Note**
 >
-> Most projects have a few use cases for `fireEvent`, but the majority of the time you should probably use [`userEvent`](./user-event).
+> Most projects have a few use cases for `fireEvent`, but the majority of the
+> time you should probably use [`userEvent`](./user-event).
 
 ## `fireEvent`
 
@@ -13,11 +26,7 @@ fireEvent(instance: TestInstance, event: EventString, eventProperties?: Object)
 Fire CLI events.
 
 ```javascript
-fireEvent(
-  getByText(instance, 'Username:'),
-  'write',
-  {value: 'crutchcorn'}
-)
+fireEvent(getByText(instance, 'Username:'), 'write', {value: 'crutchcorn'})
 ```
 
 ## `fireEvent[eventName]`
@@ -27,5 +36,5 @@ fireEvent[eventName](instance: TestInstance, eventProperties?: Object)
 ```
 
 Convenience methods for firing CLI events. Check out
-[src/event-map.js](../src/event-map.ts)
-for a full list as well as default `eventProperties`.
+[src/event-map.js](../src/event-map.ts) for a full list as well as default
+`eventProperties`.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,48 @@
+# CLI Testing Library
+
+[CLI Testing Library](https://github.com/crutchcorn/cli-testing-library) implements as-close-as-possible
+API to [DOM Testing Library](https://github.com/testing-library/dom-testing-library) and [React Testing Library](https://github.com/testing-library/react-testing-library),
+but for E2E CLI tests instead.
+
+```
+npm install --save-dev cli-testing-library
+```
+
+- [`cli-testing-library` on GitHub](https://github.com/crutchcorn/cli-testing-library)
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [The problem](#the-problem)
+- [This solution](#this-solution)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# The problem
+
+You want to write maintainable tests for your CLI applications. As a part of this goal, you want your tests to avoid
+including implementation details of your CLI and rather focus on making your tests give you the confidence for
+which they are intended. As part of this, you want your testbase to be maintainable in the long run so refactors of
+your CLI (changes to implementation but not functionality) don't break your tests and slow you and your team down.
+
+# This solution
+
+The `CLI Testing Library` is a very light-weight solution for testing CLI applications (whether written in NodeJS or not).
+The main utilities it provides involve querying `stdout` in a way that's similar to how a user interacts with CLI.
+In this way, the library helps ensure your tests give you confidence in your UI code. 
+The `CLI Testing Library`'s primary guiding principle is:
+
+> [The more your tests resemble the way your software is used, the more confidence they can give you.](https://testing-library.com/docs/guiding-principles/)
+
+As part of this goal, the utilities this library provides facilitate querying the CLI in the same way the user would.
+Finding text output with readable text, as opposed to ansi escapes interrupting (just like a user would focus on),
+sending keyboard events (like a user would), and more.
+
+This library encourages your applications to be more robust with user input and allows you to get your tests closer to
+using your command line the way a user will, which allows your tests to give you more confidence that your application 
+will work when a real user uses it.
+
+**What this library is not**:
+
+1. A test runner or framework
+2. Specific to a testing framework (though we recommend Jest as our preference, the library works with any framework.)

--- a/docs/matchers.md
+++ b/docs/matchers.md
@@ -1,0 +1,103 @@
+# Matchers
+
+The `cli-testing-library` provides a set of custom jest matchers that you can
+use to extend jest. These will make your tests more declarative, clear to read
+and to maintain.
+
+## Table of Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Usage](#usage)
+  - [With TypeScript](#with-typescript)
+- [Custom matchers](#custom-matchers)
+  - [`toBeInTheConsole`](#tobeintheconsole)
+    - [Examples](#examples)
+  - [`toHaveErrorMessage`](#tohaveerrormessage)
+    - [Examples](#examples-1)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Usage
+
+Import `cli-testing-library/extend-expect` once (for instance in your
+[tests setup file](https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array))
+and you're good to go:
+
+```javascript
+// In your own jest-setup.js (or any other name)
+import 'cli-testing-library/extend-expect'
+
+// In jest.config.js add (if you haven't already)
+setupFilesAfterEnv: ['<rootDir>/jest-setup.js']
+```
+
+### With TypeScript
+
+If you're using TypeScript, make sure your setup file is a `.ts` and not a `.js`
+to include the necessary types.
+
+You will also need to include your setup file in your `tsconfig.json` if you
+haven't already:
+
+```json
+  // In tsconfig.json
+  "include": [
+    ...
+    "./jest-setup.ts"
+  ],
+```
+
+## Custom matchers
+
+### `toBeInTheConsole`
+
+```typescript
+toBeInTheConsole()
+```
+
+This allows you to assert whether an instance is present or not. Useful when
+combined with queries (such as `getByText` or `getByError`) that return the
+`TestInstance`
+
+#### Examples
+
+```html
+Input your name:
+```
+
+```javascript
+expect(getByText(instance, 'Input your name:')).toBeInTheConsole()
+```
+
+<hr />
+
+### `toHaveErrorMessage`
+
+```typescript
+toHaveErrorMessage(text: string | RegExp)
+```
+
+This allows you to check whether the given instance has an `stderr` message or
+not.
+
+Whitespace is normalized.
+
+When a `string` argument is passed through, it will perform a whole
+case-sensitive match to the error message text.
+
+To perform a case-insensitive match, you can use a `RegExp` with the `/i`
+modifier.
+
+To perform a partial match, you can pass a `RegExp`.
+
+#### Examples
+
+```html
+File not found in output
+```
+
+```javascript
+expect(instance).toHaveErrorMessage('File not found in output')
+```

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -1,0 +1,55 @@
+# About Queries
+
+Queries are the methods that the CLI Testing Library gives you to find processes in the command line. 
+There are several types of queries ("get", "find", "query"); the difference between them 
+is whether the query will throw an error if no CLI instance is found or if it will return 
+a Promise and retry. Depending on what app content you are selecting, different 
+queries may be more or less appropriate.
+
+While our APIs [differ slightly](./differences.md) from upstream Testing Library's,
+[their "About Queries" page summarizes the goals and intentions of this project's queries quite well](https://testing-library.com/docs/queries/about/).
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Example](#example)
+- [Types of Queries](#types-of-queries)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Example
+
+```javascript
+import {render} from 'cli-testing-library'
+
+test('should show login form', () => {
+    const {getByText} = render('ftp-automation.sh')
+    const input = getByText('Username')
+    // Events and assertions...
+})
+```
+
+# Types of Queries
+
+- `getBy...`: Returns the matching CLI instance for a query, and throw a descriptive
+  error if no instances match.
+- `queryBy...`: Returns the matching CLI instance for a query, and return `null` if no
+  instances match. This is useful for asserting an instance that is not present.
+- `findBy...`: Returns a Promise which resolves when a CLI instance is found which
+  matches the given query. The promise is rejected if no instance is found after a 
+  default timeout of 1000ms.
+
+<details open>
+
+<summary>Summary Table</summary>
+
+<br />
+
+| Type of Query         | 0 Matches     | 1 Match        | >1 Matches   | Retry (Async/Await) |
+| --------------------- | ------------- | -------------- | ------------ | :-----------------: |
+| `getBy...`            | Throw error   | Return element | Throw error  |         No          |
+| `queryBy...`          | Return `null` | Return element | Throw error  |         No          |
+| `findBy...`           | Throw error   | Return element | Throw error  |         Yes         |
+
+</details>

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -21,6 +21,12 @@ Library's,
   - [Precision](#precision)
   - [Normalization](#normalization)
     - [Normalization Examples](#normalization-examples)
+- [ByText](#bytext)
+  - [API](#api)
+  - [Options](#options)
+- [ByError](#byerror)
+  - [API](#api-1)
+  - [Options](#options-1)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -69,7 +75,7 @@ for a match and `false` for a mismatch.
 
 ## TextMatch Examples
 
-Given the following output line:
+Given the following output string:
 
 ```html
 Hello World
@@ -168,3 +174,73 @@ getByText('text', {
     getDefaultNormalizer({trim: false})(str).replace(/[\u200E-\u200F]*/g, ''),
 })
 ```
+
+# ByText
+
+> getByText, queryByText, findByText
+
+## API
+
+```typescript
+getByText(
+  // If you're using the return from `render`, then skip the container argument:
+  instance: TestInstance,
+  text: TextMatch,
+  options?: {
+    exact?: boolean = true,
+    normalizer?: NormalizerFn,
+  }): HTMLElement
+```
+
+This will search the instance to see if there's an `stdout` output matching the
+given [`TextMatch`](queries/about.mdx#textmatch).
+
+```html
+Input your name:
+```
+
+```jsx
+import {render} from 'cli-testing-library'
+
+const {getByText} = render('command')
+const instance = getByText(/input your name/i)
+```
+
+## Options
+
+Contains all of the [TextMatch](#textmatch) options
+
+# ByError
+
+> getByError, queryByError, findByError
+
+## API
+
+```typescript
+getByText(
+  // If you're using the return from `render`, then skip the container argument:
+  instance: TestInstance,
+  text: TextMatch,
+  options?: {
+    exact?: boolean = true,
+    normalizer?: NormalizerFn,
+  }): HTMLElement
+```
+
+This will search the instance to see if there's an `stderr` output matching the
+given [`TextMatch`](queries/about.mdx#textmatch).
+
+```html
+Could not find file
+```
+
+```jsx
+import {render} from 'cli-testing-library'
+
+const {getByError} = render('command')
+const instance = getByError(/not find file/)
+```
+
+## Options
+
+Contains all of the [TextMatch](#textmatch) options

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -1,17 +1,18 @@
 # About Queries
 
-Queries are the methods that the CLI Testing Library gives you to find processes in the command line. 
-There are several types of queries ("get", "find", "query"); the difference between them 
-is whether the query will throw an error if no CLI instance is found or if it will return 
-a Promise and retry. Depending on what app content you are selecting, different 
-queries may be more or less appropriate.
+Queries are the methods that the CLI Testing Library gives you to find processes
+in the command line. There are several types of queries ("get", "find",
+"query"); the difference between them is whether the query will throw an error
+if no CLI instance is found or if it will return a Promise and retry. Depending
+on what app content you are selecting, different queries may be more or less
+appropriate.
 
-While our APIs [differ slightly](./differences.md) from upstream Testing Library's,
+While our APIs [differ slightly](./differences.md) from upstream Testing
+Library's,
 [their "About Queries" page summarizes the goals and intentions of this project's queries quite well](https://testing-library.com/docs/queries/about/).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 
 - [Example](#example)
 - [Types of Queries](#types-of-queries)
@@ -29,21 +30,22 @@ While our APIs [differ slightly](./differences.md) from upstream Testing Library
 import {render} from 'cli-testing-library'
 
 test('should show login form', () => {
-    const {getByText} = render('ftp-automation.sh')
-    const input = getByText('Username')
-    // Events and assertions...
+  const {getByText} = render('ftp-automation.sh')
+  const input = getByText('Username')
+  // Events and assertions...
 })
 ```
 
 # Types of Queries
 
-- `getBy...`: Returns the matching CLI instance for a query, and throw a descriptive
-  error if no instances match.
-- `queryBy...`: Returns the matching CLI instance for a query, and return `null` if no
-  instances match. This is useful for asserting an instance that is not present.
-- `findBy...`: Returns a Promise which resolves when a CLI instance is found which
-  matches the given query. The promise is rejected if no instance is found after a 
-  default timeout of 1000ms.
+- `getBy...`: Returns the matching CLI instance for a query, and throw a
+  descriptive error if no instances match.
+- `queryBy...`: Returns the matching CLI instance for a query, and return `null`
+  if no instances match. This is useful for asserting an instance that is not
+  present.
+- `findBy...`: Returns a Promise which resolves when a CLI instance is found
+  which matches the given query. The promise is rejected if no instance is found
+  after a default timeout of 1000ms.
 
 <details open>
 
@@ -51,11 +53,11 @@ test('should show login form', () => {
 
 <br />
 
-| Type of Query         | 0 Matches     | 1 Match        | >1 Matches   | Retry (Async/Await) |
-| --------------------- | ------------- | -------------- | ------------ | :-----------------: |
-| `getBy...`            | Throw error   | Return element | Throw error  |         No          |
-| `queryBy...`          | Return `null` | Return element | Throw error  |         No          |
-| `findBy...`           | Throw error   | Return element | Throw error  |         Yes         |
+| Type of Query | 0 Matches     | 1 Match        | >1 Matches  | Retry (Async/Await) |
+| ------------- | ------------- | -------------- | ----------- | :-----------------: |
+| `getBy...`    | Throw error   | Return element | Throw error |         No          |
+| `queryBy...`  | Return `null` | Return element | Throw error |         No          |
+| `findBy...`   | Throw error   | Return element | Throw error |         Yes         |
 
 </details>
 
@@ -121,10 +123,11 @@ can contain options that affect the precision of string matching:
 
 ## Normalization
 
-Before running any matching logic against text in `stdout`, `CLI Testing Library`
-automatically normalizes that text. By default, normalization consists of
-trimming whitespace from the start and end of text, collapsing multiple
-adjacent whitespace characters into a single space, and removing [ANSI escapes](https://en.wikipedia.org/wiki/ANSI_escape_code).
+Before running any matching logic against text in `stdout`,
+`CLI Testing Library` automatically normalizes that text. By default,
+normalization consists of trimming whitespace from the start and end of text,
+collapsing multiple adjacent whitespace characters into a single space, and
+removing [ANSI escapes](https://en.wikipedia.org/wiki/ANSI_escape_code).
 
 If you want to prevent that normalization, or provide alternative normalization
 (e.g. to remove Unicode control characters), you can provide a `normalizer`
@@ -143,7 +146,8 @@ behaviour:
 - `trim`: Defaults to `true`. Trims leading and trailing whitespace
 - `collapseWhitespace`: Defaults to `true`. Collapses inner whitespace
   (newlines, tabs, repeated spaces) into a single space.
-- `stripAnsi`: Defaults to `true`. Removes ANSI escapes from `stdout` entirely to leave only human-readible text.
+- `stripAnsi`: Defaults to `true`. Removes ANSI escapes from `stdout` entirely
+  to leave only human-readible text.
 
 ### Normalization Examples
 

--- a/docs/user-event.md
+++ b/docs/user-event.md
@@ -1,0 +1,104 @@
+[`user-event`][gh] is a helper that provides more
+advanced simulation of CLI interactions than the [`fireEvent`](./fire-event) method.
+
+## Import
+
+`userEvent` can be used either as a global import or as returned from `render`:
+
+```javascript
+import {userEvent} from 'cli-testing-library'
+```
+
+Or:
+
+```js
+import {render} from 'cli-testing-library'
+
+const {userEvent} = render('command')
+```
+
+## API
+
+Note: All `userEvent` methods are synchronous with one exception: when `delay`
+option used with `userEvent.keyboard` as described below. We also discourage using
+`userEvent` inside `before/after` blocks at all, for important reasons described
+in
+["Avoid Nesting When You're Testing"](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing).
+
+### `keyboard(instance, text, [options])`
+
+Writes `text` inside a CLI's `stdin` buffer
+
+```jsx
+import {render} from 'cli-testing-library'
+
+test('type', () => {
+  const {getByText, userEvent} = render('command')
+
+  userEvent.keyboard('Hello, World![Enter]')
+  expect(getByText('Hello, world!')).toBeTruthy();
+})
+```
+
+`options.delay` is the number of milliseconds that pass between two characters
+are typed. By default it's 0. You can use this option if your component has a
+different behavior for fast or slow users. If you do this, you need to make sure
+to `await`!
+
+<!-- space out these notes -->
+
+Keystrokes can be described:
+
+- Per printable character
+  ```js
+  userEvent.keyboard('foo') // translates to: f, o, o
+  ```
+  The bracket `[` is used as a special character and can be referenced
+  by doubling it.
+  
+  ```js
+  userEvent.keyboard('a[[') // translates to: a, [
+  ```
+  
+- Per [special key mapping](../src/user-event/keyboard/keyMap.ts) with the `[` symbol
+  
+  ```js
+  userEvent.keyboard('[ArrowLeft][KeyF][KeyO][KeyO]') // translates to: Left Arrow, f, o, o
+  ```
+  This does not keep any key pressed. So `Shift` will be lifted before pressing
+  `f`.
+
+The mapping of special character strings are performed by a
+[default key map](../src/user-event/keyboard/keyMap.ts)
+portraying a "default" US-keyboard. You can provide your own local keyboard
+mapping per option.
+
+```js
+userEvent.keyboard('?', {keyboardMap: myOwnLocaleKeyboardMap})
+```
+
+<!-- space out these notes -->
+
+
+#### Special characters
+
+We support inputting many special character strings with the `[` syntax mentioned previously. Here are some of the ones that are supported:
+
+| Text string    | Key name    |
+| -------------- | ----------- |
+| `[Enter]`      | Enter       |
+| `[Space]`      | `' '`       |
+| `[Escape]`     | Escape      |
+| `[Backspace]`  | Backspace   |
+| `[Delete]`     | Delete      |
+| `[ArrowLeft]`  | Left Arrow  |
+| `[ArrowRight]` | Right Arrow |
+| `[ArrowUp]`    | Up Arrow    |
+| `[ArrowDown]`  | Down Arrow  |
+| `[Home]`       | Home        |
+| `[End]`        | End         |
+
+A full list of supported special characters that can be input can be found [in our key mapping file](../src/user-event/keyboard/keyMap.ts).
+
+
+[gh]: https://github.com/testing-library/user-event

--- a/docs/user-event.md
+++ b/docs/user-event.md
@@ -1,5 +1,18 @@
-[`user-event`][gh] is a helper that provides more
-advanced simulation of CLI interactions than the [`fireEvent`](./fire-event) method.
+[`user-event`][gh] is a helper that provides more advanced simulation of CLI
+interactions than the [`fireEvent`](./fire-event) method.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+**Table of Contents** _generated with
+[DocToc](https://github.com/thlorenz/doctoc)_
+
+- [Import](#import)
+- [API](#api)
+  - [`keyboard(instance, text, [options])`](#keyboardinstance-text-options)
+    - [Special characters](#special-characters)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Import
 
@@ -20,9 +33,9 @@ const {userEvent} = render('command')
 ## API
 
 Note: All `userEvent` methods are synchronous with one exception: when `delay`
-option used with `userEvent.keyboard` as described below. We also discourage using
-`userEvent` inside `before/after` blocks at all, for important reasons described
-in
+option used with `userEvent.keyboard` as described below. We also discourage
+using `userEvent` inside `before/after` blocks at all, for important reasons
+described in
 ["Avoid Nesting When You're Testing"](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing).
 
 ### `keyboard(instance, text, [options])`
@@ -36,7 +49,7 @@ test('type', () => {
   const {getByText, userEvent} = render('command')
 
   userEvent.keyboard('Hello, World![Enter]')
-  expect(getByText('Hello, world!')).toBeTruthy();
+  expect(getByText('Hello, world!')).toBeTruthy()
 })
 ```
 
@@ -50,28 +63,31 @@ to `await`!
 Keystrokes can be described:
 
 - Per printable character
+
   ```js
   userEvent.keyboard('foo') // translates to: f, o, o
   ```
-  The bracket `[` is used as a special character and can be referenced
-  by doubling it.
-  
+
+  The bracket `[` is used as a special character and can be referenced by
+  doubling it.
+
   ```js
   userEvent.keyboard('a[[') // translates to: a, [
   ```
-  
-- Per [special key mapping](../src/user-event/keyboard/keyMap.ts) with the `[` symbol
-  
+
+- Per [special key mapping](../src/user-event/keyboard/keyMap.ts) with the `[`
+  symbol
+
   ```js
   userEvent.keyboard('[ArrowLeft][KeyF][KeyO][KeyO]') // translates to: Left Arrow, f, o, o
   ```
+
   This does not keep any key pressed. So `Shift` will be lifted before pressing
   `f`.
 
 The mapping of special character strings are performed by a
-[default key map](../src/user-event/keyboard/keyMap.ts)
-portraying a "default" US-keyboard. You can provide your own local keyboard
-mapping per option.
+[default key map](../src/user-event/keyboard/keyMap.ts) portraying a "default"
+US-keyboard. You can provide your own local keyboard mapping per option.
 
 ```js
 userEvent.keyboard('?', {keyboardMap: myOwnLocaleKeyboardMap})
@@ -79,10 +95,10 @@ userEvent.keyboard('?', {keyboardMap: myOwnLocaleKeyboardMap})
 
 <!-- space out these notes -->
 
-
 #### Special characters
 
-We support inputting many special character strings with the `[` syntax mentioned previously. Here are some of the ones that are supported:
+We support inputting many special character strings with the `[` syntax
+mentioned previously. Here are some of the ones that are supported:
 
 | Text string    | Key name    |
 | -------------- | ----------- |
@@ -98,7 +114,7 @@ We support inputting many special character strings with the `[` syntax mentione
 | `[Home]`       | Home        |
 | `[End]`        | End         |
 
-A full list of supported special characters that can be input can be found [in our key mapping file](../src/user-event/keyboard/keyMap.ts).
-
+A full list of supported special characters that can be input can be found
+[in our key mapping file](../src/user-event/keyboard/keyMap.ts).
 
 [gh]: https://github.com/testing-library/user-event

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import {Config, ConfigFn} from '../types/config'
-import {TestInstance} from "../types/pure";
+import {TestInstance} from '../types/pure'
 // import {prettyDOM} from './pretty-dom'
 
 type Callback<T> = () => T
@@ -11,25 +11,14 @@ interface InternalConfig extends Config {
 // other parts of the code assume that all exports from
 // './queries' are query functions.
 let config: InternalConfig = {
-  testIdAttribute: 'data-testid',
   asyncUtilTimeout: 1000,
   // Short amount of time to wait for your process to spin up after a `spawn`. AFAIK There's unfortunately not much
   // of a better way to do this
   renderAwaitTime: 100,
   // Internal timer time to wait before attempting error recovery debounce action
   errorDebounceTimeout: 100,
-  // asyncWrapper and advanceTimersWrapper is to support React's async `act` function.
-  // forcing react-testing-library to wrap all async functions would've been
-  // a total nightmare (consider wrapping every findBy* query and then also
-  // updating `within` so those would be wrapped too. Total nightmare).
-  // so we have this config option that's really only intended for
-  // react-testing-library to use. For that reason, this feature will remain
-  // undocumented.
-  asyncWrapper: cb => cb(),
   unstable_advanceTimersWrapper: cb => cb(),
-  eventWrapper: cb => cb(),
   // default value for the `hidden` option in `ByRole` queries
-  defaultHidden: false,
   // showOriginalStackTrace flag to show the full error stack traces for async errors
   showOriginalStackTrace: false,
 
@@ -39,10 +28,7 @@ let config: InternalConfig = {
   // called when getBy* queries fail. (message, container) => Error
   getInstanceError(message, testInstance: TestInstance | undefined) {
     const error = new Error(
-      [
-        message,
-        testInstance ? `\n${testInstance.stdoutArr.join('\n')}` : '',
-      ]
+      [message, testInstance ? `\n${testInstance.stdoutArr.join('\n')}` : '']
         .filter(Boolean)
         .join('\n\n'),
     )
@@ -50,7 +36,6 @@ let config: InternalConfig = {
     return error
   },
   _disableExpensiveErrorDiagnostics: false,
-  computedStyleSupportsPseudoElements: false,
 }
 
 export function runWithExpensiveErrorDiagnosticsDisabled<T>(

--- a/src/matchers/to-be-in-the-console.js
+++ b/src/matchers/to-be-in-the-console.js
@@ -1,13 +1,15 @@
 /* eslint-disable @babel/no-invalid-this */
-import {getDefaultNormalizer} from "../matches";
-import {checkCliInstance, getMessage} from "./utils";
+import {getDefaultNormalizer} from '../matches'
+import {checkCliInstance, getMessage} from './utils'
 
 export function toBeInTheConsole(instance) {
   if (instance !== null || !this.isNot) {
     checkCliInstance(instance, toBeInTheConsole, this)
   }
 
-  const errormessage = instance ? getDefaultNormalizer()(instance.stderrArr.join('\n')) : null
+  const errormessage = instance
+    ? getDefaultNormalizer()(instance.stdoutArr.join('\n'))
+    : null
 
   return {
     // Does not change based on `.not`, and as a result, we must confirm if it _actually_ is there
@@ -15,17 +17,17 @@ export function toBeInTheConsole(instance) {
     message: () => {
       const to = this.isNot ? 'not to' : 'to'
       return getMessage(
-          this,
-          this.utils.matcherHint(
-              `${this.isNot ? '.not' : ''}.toBeInTheConsole`,
-              'instance',
-              '',
-          ),
-          `Expected ${to} find the instance in the console`,
-          "",
-          'Received',
-          this.utils.printReceived(errormessage),
+        this,
+        this.utils.matcherHint(
+          `${this.isNot ? '.not' : ''}.toBeInTheConsole`,
+          'instance',
+          '',
+        ),
+        `Expected ${to} find the instance in the console`,
+        '',
+        'Received',
+        this.utils.printReceived(errormessage),
       )
-    }
+    },
   }
 }

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -7,7 +7,7 @@ import userEvent from './user-event'
 import {bindObjectFnsToInstance, setCurrentInstance} from './helpers'
 import {fireEvent} from './events'
 import {getConfig} from './config'
-import {logCLI} from "./pretty-cli";
+import {logCLI} from './pretty-cli'
 
 const mountedInstances = new Set<TestInstance>()
 
@@ -40,6 +40,7 @@ async function render(
     // Clear buffer of stdout to do more accurate `t.regex` checks
     clear() {
       execOutputAPI.stdoutArr = []
+      execOutputAPI.stderrArr = []
     },
     debug(maxLength?: number) {
       logCLI(execOutputAPI, maxLength)

--- a/src/user-event/keyboard/index.ts
+++ b/src/user-event/keyboard/index.ts
@@ -1,5 +1,4 @@
-import {getConfig as getCLITestingLibraryConfig} from '../../config';
-import {TestInstance} from "../../../types";
+import {TestInstance} from '../../../types'
 import {keyboardImplementation} from './keyboardImplementation'
 import {defaultKeyMap} from './keyMap'
 import {keyboardOptions, keyboardKey} from './types'
@@ -7,37 +6,32 @@ import {keyboardOptions, keyboardKey} from './types'
 export type {keyboardOptions, keyboardKey}
 
 export function keyboard(
-    instance: TestInstance,
-    text: string,
-    options?: Partial<keyboardOptions & {delay: number}>,
+  instance: TestInstance,
+  text: string,
+  options?: Partial<keyboardOptions & {delay: number}>,
 ): void | Promise<void> {
-    const {promise} = keyboardImplementationWrapper(instance, text, options)
+  const {promise} = keyboardImplementationWrapper(instance, text, options)
 
-    if ((options?.delay ?? 0) > 0) {
-        return getCLITestingLibraryConfig().asyncWrapper(() =>
-            promise,
-        )
-    } else {
-        // prevent users from dealing with UnhandledPromiseRejectionWarning in sync call
-        promise.catch(console.error)
-    }
+  if ((options?.delay ?? 0) > 0) {
+    return promise
+  } else {
+    // prevent users from dealing with UnhandledPromiseRejectionWarning in sync call
+    promise.catch(console.error)
+  }
 }
 
 export function keyboardImplementationWrapper(
-    instance: TestInstance,
-    text: string,
-    config: Partial<keyboardOptions> = {},
+  instance: TestInstance,
+  text: string,
+  config: Partial<keyboardOptions> = {},
 ) {
-    const {
-        delay = 0,
-        keyboardMap = defaultKeyMap,
-    } = config
-    const options = {
-        delay,
-        keyboardMap,
-    }
+  const {delay = 0, keyboardMap = defaultKeyMap} = config
+  const options = {
+    delay,
+    keyboardMap,
+  }
 
-    return {
-        promise: keyboardImplementation(instance, text, options)
-    }
+  return {
+    promise: keyboardImplementation(instance, text, options),
+  }
 }

--- a/src/wait-for.js
+++ b/src/wait-for.js
@@ -2,7 +2,7 @@
 // TODO: Migrate back to use `config.js` file
 import {getCurrentInstance, jestFakeTimersAreEnabled} from './helpers'
 import {MutationObserver} from './mutation-observer'
-import {getConfig} from "./config";
+import {getConfig} from './config'
 
 // This is so the stack trace the developer sees is one that's
 // closer to their code (because async stack traces are hard to follow).
@@ -20,9 +20,9 @@ function waitFor(
     interval = 50,
     onTimeout = error => {
       error.message = getConfig().getInstanceError(
-                error.message,
-                instance,
-            ).message
+        error.message,
+        instance,
+      ).message
       return error
     },
   },
@@ -40,7 +40,7 @@ function waitFor(
 
     const usingJestFakeTimers = jestFakeTimersAreEnabled()
     if (usingJestFakeTimers) {
-      const { unstable_advanceTimersWrapper: advanceTimersWrapper } = getConfig()
+      const {unstable_advanceTimersWrapper: advanceTimersWrapper} = getConfig()
       checkCallback()
       // this is a dangerous rule to disable because it could lead to an
       // infinite loop. However, eslint isn't smart enough to know that we're
@@ -169,9 +169,7 @@ function waitForWrapper(callback, options) {
   // create the error here so its stack trace is as close to the
   // calling code as possible
   const stackTraceError = new Error('STACK_TRACE_MESSAGE')
-  return getConfig().asyncWrapper(() =>
-        waitFor(callback, {stackTraceError, ...options}),
-    )
+  return waitFor(callback, {stackTraceError, ...options})
 }
 
 export {waitForWrapper as waitFor}

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -1,21 +1,14 @@
-import {TestInstance} from "./pure";
+import {TestInstance} from './pure'
 
 export interface Config {
-  testIdAttribute: string
   /**
    * WARNING: `unstable` prefix means this API may change in patch and minor releases.
    * @param cb
    */
   unstable_advanceTimersWrapper(cb: (...args: unknown[]) => unknown): unknown
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  asyncWrapper(cb: (...args: any[]) => any): Promise<any>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  eventWrapper(cb: (...args: any[]) => any): void
   asyncUtilTimeout: number
   renderAwaitTime: number
   errorDebounceTimeout: number
-  computedStyleSupportsPseudoElements: boolean
-  defaultHidden: boolean
   showOriginalStackTrace: boolean
   throwSuggestions: boolean
   getInstanceError: (message: string | null, container: TestInstance) => Error

--- a/types/pure.d.ts
+++ b/types/pure.d.ts
@@ -28,6 +28,6 @@ export type RenderResult = TestInstance & {
 
 export function render(
   command: string,
-  args: string[],
+  args?: string[],
   opts?: Partial<RenderOptions>,
 ): Promise<RenderResult>


### PR DESCRIPTION
This PR introduces early docs for the project. These docs, as I'm writing them, may influence the API - like it did when we introduced `userEvent`

Note that our docs are intended to align as closely with upstream's (Testing Library) as possible, while also providing docs like `differences.md` to quickstart devs that are already familiar with upstream.

Once these docs are completed, we'll be releasing v1 (with the understanding that pending feedback in #2 we may likely push a v2 soon after)