### PR TITLE
fix(esm): add exports map to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,18 @@
   "version": "0.0.0-semantically-released",
   "description": "Simple and complete CLI testing utilities that encourage good testing practices.",
   "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "require": "./dist/cli-testing-library.cjs.js",
+      "import": "./dist/cli-testing-library.esm.js"
+    },
+    "./extend-expect": {
+      "types": "./extend-expect.d.ts",
+      "require": "./dist/extend-expect.js",
+      "import": "./dist/extend-expect.js"
+    }
+  },
   "types": "types/index.d.ts",
   "module": "dist/cli-testing-library.esm.js",
   "umd:main": "dist/cli-testing-library.umd.js",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->
Resolves https://github.com/crutchcorn/cli-testing-library/issues/17

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I'm not 100% sure you can point to the same file for both `import` and `require` in the `exports` map, but I assume we can (I looked at https://unpkg.com/browse/@testing-library/jest-dom@5.16.4/package.json and they don't seem to have something special for ESM, so I guess it should work). 