### PR TITLE
Update README: change `cleanup` -> `clear`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ const {resolve} = require('path')
 const {render} = require('cli-testing-library')
 
 test('Is able to make terminal input and view in-progress stdout', async () => {
-  const {cleanup, findByText, queryByText, userEvent} = await render('node', [
+  const {clear, findByText, queryByText, userEvent} = await render('node', [
     resolve(__dirname, './execute-scripts/stdio-inquirer.js'),
   ])
 
@@ -79,13 +79,13 @@ test('Is able to make terminal input and view in-progress stdout', async () => {
 
   expect(await findByText('❯ One')).toBeInTheConsole()
 
-  cleanup()
+  clear()
 
   userEvent('[ArrowDown]')
 
   expect(await findByText('❯ Two')).toBeInTheConsole()
 
-  cleanup()
+  clear()
 
   userEvent.keyboard('[Enter]')
 


### PR DESCRIPTION
**What**:

Typo fix on the README.

The code example on the README uses a function `cleanup`, but I think it is supposed to be `clear`, as `cleanup` is not part of the `RenderResult` type but `clear` is.

**Why**:

Clarity

**How**:

Find/replace on README.md

**Checklist**:

- [x] Tests n/a
- [x] TypeScript definitions updated n/a
- [x] Ready to be merged
