### PR TITLE
fix: update killProc to retry unsupported taskkill operations with the alternative kill method

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thanks for being willing to contribute!
 > requests from branches on your fork. To do this, run:
 >
 > ```
-> git remote add upstream https://github.com/testing-library/dom-testing-library.git
+> git remote add upstream https://github.com/crutchcorn/cli-testing-library.git
 > git fetch upstream
 > git branch --set-upstream-to=upstream/main main
 > ```

--- a/src/process-helpers.ts
+++ b/src/process-helpers.ts
@@ -21,8 +21,15 @@ export const killProc = (instance: TestInstance, signal: string | undefined) =>
           }
           if (
             err.message.includes('could not be terminated') &&
-            err.message.includes('There is no running instance of the task.')
+            err.message.includes('There is no running instance of the task.') &&
+            instance.hasExit()
           ) {
+            resolve()
+            return
+          }
+          const isOperationNotSupported = err.message.includes('The operation attempted is not supported.');
+          const isAccessDenied = err.message.includes('Access is denied.');
+          if (err.message.includes('could not be terminated') && (isOperationNotSupported || isAccessDenied)) {
             const sleep = (t: number) => new Promise(r => setTimeout(r, t))
             await sleep(getConfig().errorDebounceTimeout)
             if (instance.hasExit()) {


### PR DESCRIPTION
**What**:
Retrying to kill a process when treeKill returns an error with the reason: the operation attempted is not supported.

**Why**:
This error was encountered with windows systems, when using the exec function on a child process.
The CI pipeline would sometimes encounter this error (flaky testing).
/claim #3 

**How**:
- update killProc function to use the existing retry logic when the error returned is specifically the unsupported taskkill operations error
- update killProc function to resolve when the error returned states that the process has no running instances rather than use the retry logic

**Checklist**:
- [ ] Tests "N/A"
- [ ] TypeScript definitions updated "N/A"
- [ x ] Ready to be merged
