### PR TITLE
Ensure `user-event` folder is included into final bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "files": [
     "dist",
     "types/*.d.ts",
+    "types/user-event/**/*.d.ts",
     "extend-expect.js",
     "extend-expect.d.ts",
     "src/user-event/**/*.ts",


### PR DESCRIPTION
**What**:

With the changes introduced in #24, there's a `user-events` folder inside the `types` folder that isn't being added to the final, published, library. This change ensures that this folder is also included.

**Why**:

![image](https://github.com/user-attachments/assets/747476bf-978e-49ab-af15-6286b6dd8937)

Since there's a reference to the folder inside of `types/pure.d.ts`, the whole types for the `userEvent` library become `any`.

**How**:

By adding `types/user-event/**/*.d.ts` to the list of included files, we're ensuring the final bundle also includes the content of the `types/user-event` folder.

**Checklist**:

- [N/A] Tests
- [N/A] TypeScript definitions updated
- [N/A] Ready to be merged
