### PR TITLE
docs: fix docs link, improve liking

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -51,11 +51,12 @@ will work when a real user uses it.
 
 # Further Reading
 
-- [API reference for `render` and friends](./api)
-- [Jest and Vitest matchers](./matchers)
-- [Mock user input](./user-event)
-- [Manually fire input events](./fire-event)
-- [Output matching queries](./queries)
-- [Debugging "CLI Testing Library" tests](./debug)
-- [Configure library options](./configure)
-- [Differences between us and other "Testing Library" projects](./differences)
+- [API reference for `render` and friends](./api.md)
+- [Jest and Vitest matchers](./matchers.md)
+- [Mock user input](./user-event.md)
+- [Manually fire input events](./fire-event.md)
+- [Output matching queries](./queries.md)
+- [Debugging "CLI Testing Library" tests](./debug.md)
+- [Configure library options](./configure.md)
+- [Differences between us and other "Testing Library" projects](./differences.md)
+

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -51,12 +51,11 @@ will work when a real user uses it.
 
 # Further Reading
 
-- [API reference for `render` and friends](./api.md)
-- [Jest and Vitest matchers](./matchers.md)
-- [Mock user input](./user-event.md)
-- [Manually fire input events](./fire-event.md)
-- [Output matching queries](./queries.md)
-- [Debugging "CLI Testing Library" tests](./debug.md)
-- [Configure library options](./configure.md)
-- [Differences between us and other "Testing Library" projects](./differences.md)
-
+- [API reference for `render` and friends](./api)
+- [Jest and Vitest matchers](./matchers)
+- [Mock user input](./user-event)
+- [Manually fire input events](./fire-event)
+- [Output matching queries](./queries)
+- [Debugging "CLI Testing Library" tests](./debug)
+- [Configure library options](./configure)
+- [Differences between us and other "Testing Library" projects](./differences)

--- a/packages/cli-testing-library/README.md
+++ b/packages/cli-testing-library/README.md
@@ -98,7 +98,7 @@ test("Is able to make terminal input and view in-progress stdout", async () => {
 
 For a API reference documentation, including suggestions on how to use this
 library, see our
-[documentation introduction with further reading](./docs/introduction.md).
+[documentation introduction with further reading](https://cli-testing.com/guides/introduction/).
 
 > While this library _does_ work in Windows, it does not appear to function
 > properly in Windows CI environments, such as GitHub actions. As a result, you

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -15,7 +15,7 @@ hero:
   actions:
     - text: Get started
       icon: right-arrow
-      link: /guides/introduction/
+      link: /guides/introduction
     - text: View on GitHub
       icon: external
       variant: minimal


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

When browsing docs intro package through README.md it lead me to: https://github.com/crutchcorn/cli-testing-library/blob/main/docs/introduction.md
Then when clicking on any further reading links returned 404.

<!-- Why are these changes necessary? -->

**Why**:

1. The links missed `.md` extension: e.g. https://github.com/crutchcorn/cli-testing-library/blob/main/docs/api instead of https://github.com/crutchcorn/cli-testing-library/blob/main/docs/api.md.

2. Additionally, the README.md linked to github docs folder: https://github.com/crutchcorn/cli-testing-library/blob/main/docs/introduction.md instead of docs website: https://cli-testing.com/guides/introduction/


<!-- How were these changes implemented? -->

**How**:

Updated relevant links. Checked that generated website supports internal links with `.md` extension.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests - N/A
- [x] TypeScript definitions updated - N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
