### PR TITLE
fix: support usage of `.` in keyboard user-events

### DIFF
--- a/packages/cli-testing-library/src/user-event/keyboard/keyMap.ts
+++ b/packages/cli-testing-library/src/user-event/keyboard/keyMap.ts
@@ -19,6 +19,7 @@ export const defaultKeyMap: Array<keyboardKey> = [
   { code: "Digit)", hex: "\x29" },
   { code: "Digit*", hex: "\x2a" },
   { code: "Digit-", hex: "\x2d" },
+  { code: "Digit.", hex: "\x2e" },
   { code: "Digit@", hex: "\x40" },
   { code: "Digit^", hex: "\x5e" },
   { code: "Digit{", hex: "\x7b" },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Adds a period (".") into the current user-event keyboard map.

<!-- Why are these changes necessary? -->

**Why**:

Currently, the following code produces unexpected results:
```js
userEvent.keyboard('user@email.com');
```

outputs the following into the console:
```
user@emailUnknowncom
```

<!-- How were these changes implemented? -->

**How**:

Updated the `defaultKeyMap` to contain a value for `.` (`\x2e` hex code)

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests (N\A)
- [x] TypeScript definitions updated (N\A)
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

(I believe it's unnecessary to update tests for this as I didn't see existing specs that covered this keyMap, but correct me if I'm wrong)