### PR TITLE
fix: support Vitest 3.2.0+

### DIFF
--- a/packages/cli-testing-library/src/vitest.ts
+++ b/packages/cli-testing-library/src/vitest.ts
@@ -11,4 +11,7 @@ declare module "vitest" {
 
   interface AsymmetricMatchersContaining
     extends CLITestingLibraryMatchers<any> {}
+
+  // Vitest 3.2.0+
+  interface Matchers<T = any> extends CLITestingLibraryMatchers<T> {}
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add support for Vitest 3.2.0+ for extended matchers
See https://vitest.dev/guide/extending-matchers

<!-- Why are these changes necessary? -->

**Why**: Vitest 3.2.0+ changed how type definitions for extended matchers are defined

<!-- How were these changes implemented? -->

**How**: Adding the type definition for Vitest 3.2.0+ while keeping type definitions for Vitest < 3.2.0

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests (N/A)
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
